### PR TITLE
Fonts

### DIFF
--- a/theme/padplus/scss/post.scss
+++ b/theme/padplus/scss/post.scss
@@ -1,1 +1,3 @@
 // Post SCSS is useful for defining full CSS rules. Because they are included last, they override any previous matching selector with the same specificity.
+
+@import 'post/fonts.scss';

--- a/theme/padplus/scss/post/_fonts.scss
+++ b/theme/padplus/scss/post/_fonts.scss
@@ -1,0 +1,43 @@
+body {
+    font-family: Roboto !default;
+    font-style: normal;
+    color: #000000;
+}
+
+h1 {
+    font-weight: bold;
+    font-size: 32px;
+    line-height: 150%;
+}
+
+h2 {
+    font-weight: bold;
+    font-size: 24px;
+    line-height: 150%;
+}
+
+h3 {
+    font-weight: normal;
+    font-size: 18px;
+    line-height: 24px;
+}
+
+h4 {
+    font-weight: normal;
+    font-size: 16px;
+    line-height: 24px;
+}
+
+h5 {
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 150%;
+    font-style: normal;
+    color: #4C8341;
+}
+    
+p, a {
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 150%;
+}

--- a/theme/padplus/scss/post/_fonts.scss
+++ b/theme/padplus/scss/post/_fonts.scss
@@ -1,43 +1,43 @@
 body {
     font-family: Roboto !default;
     font-style: normal;
-    color: #000000;
+    color: $black;
 }
 
 h1 {
-    font-weight: bold;
-    font-size: 32px;
-    line-height: 150%;
+    color: #4C8341;
+    font-weight: $font-weight-bold;
+    font-size: $h1-font-size;
+    line-height: 48px;
 }
 
 h2 {
-    font-weight: bold;
+    color: #4C8341;
+    font-weight: $font-weight-bold;
     font-size: 24px;
-    line-height: 150%;
+    line-height: 36px;
 }
 
 h3 {
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     font-size: 18px;
     line-height: 24px;
 }
 
 h4 {
-    font-weight: normal;
+    font-weight: $font-weight-bold;
     font-size: 16px;
-    line-height: 24px;
+    line-height: 30px;
 }
 
 h5 {
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 150%;
-    font-style: normal;
-    color: #4C8341;
+    font-weight: $font-weight-normal;
+    font-size: $h5-font-size;
+    line-height: 24px;
 }
-    
+
 p, a {
     font-weight: normal;
     font-size: 14px;
-    line-height: 150%;
+    line-height: 21px;
 }

--- a/theme/padplus/scss/pre.scss
+++ b/theme/padplus/scss/pre.scss
@@ -1,12 +1,20 @@
 // // By setting this variables in pre.scss we can override the default value of this variable everywhere it is used.
-@font-face {
-    font-family: 'Roboto-Medium';
-    src: url('Roboto-Medium.eot');
-    src: url('Roboto-Medium.eot') format('embedded-opentype'),
-         url('Roboto-Medium.woff2') format('woff2'),
-         url('Roboto-Medium.woff') format('woff'),
-         url('Roboto-Medium.ttf') format('truetype'),
-         url('Roboto-Medium.svg#Roboto-Medium') format('svg');
-    font-weight: 500;
-    font-style: normal;
-}
+
+// Fonts variables
+$h1-font-size: 32px;
+$h2-font-size: 24px;
+$h3-font-size: 18px;
+$h4-font-size: 16px;
+$h5-font-size: 16px;
+
+// Colors
+$pantone: #B8CDEC;
+$pantone-yellow: #FFDE16;
+$pantone-299: #00A8E2;
+$pantone-301: #234395;
+$pantone-362: #3BA847;
+$pantone-368: #76B82A;
+$pantone-380: #D5DA2E;
+$pantone-567: #07413F;
+$pantone-660: #1C75BC;
+$pantone-2766: #292960;

--- a/theme/padplus/scss/pre.scss
+++ b/theme/padplus/scss/pre.scss
@@ -1,1 +1,12 @@
-// By setting this variables in pre.scss we can override the default value of this variable everywhere it is used.
+// // By setting this variables in pre.scss we can override the default value of this variable everywhere it is used.
+@font-face {
+    font-family: 'Roboto-Medium';
+    src: url('Roboto-Medium.eot');
+    src: url('Roboto-Medium.eot') format('embedded-opentype'),
+         url('Roboto-Medium.woff2') format('woff2'),
+         url('Roboto-Medium.woff') format('woff'),
+         url('Roboto-Medium.ttf') format('truetype'),
+         url('Roboto-Medium.svg#Roboto-Medium') format('svg');
+    font-weight: 500;
+    font-style: normal;
+}


### PR DESCRIPTION
Nous avons défini les variables de couleur et de taille dans le fichier pre.scss. Par contre, pre.scss n'est pas encore opérationnel. Difficulté à écraser les variables boostrap par le fichier pre.scss. 

Dans le fichier _fonts.scss nous avons indiqué la police et les propriétés correspondant à chaque titre. Ces propriétés ne s'appliquent pas dans tous les cas, elles sont susceptibles d'être écrasées par des classes ou des id spécifiques.


