### PR TITLE
Replace message_popover core by theme padplus template

### DIFF
--- a/theme/padplus/templates/core_message/message_popover.mustache
+++ b/theme/padplus/templates/core_message/message_popover.mustache
@@ -38,7 +38,7 @@
 <div class="popover-region collapsed" data-region="popover-region-messages">
     <a id="message-drawer-toggle-{{uniqid}}" class="nav-link d-inline-block popover-region-toggle position-relative icon-no-margin" href="{{{ config.wwwroot }}}/message/index.php"
             role="button">
-        {{#pix}} t/message, core, {{#str}} togglemessagemenu, message {{/str}} {{/pix}}
+        {{#pix}} t/message-padplus, core, {{#str}} togglemessagemenu, message {{/str}} {{/pix}}
         <div class="count-container {{^unreadcount}}hidden{{/unreadcount}}" data-region="count-container"
         aria-label="{{#str}} unreadconversations, core_message, {{unreadcount}} {{/str}}">{{unreadcount}}</div>
     </a>


### PR DESCRIPTION
Fixed original message core template -
Added a copy in theme_padplus