### PR TITLE
Pad fix dropdown item

### DIFF
--- a/theme/padplus/scss/post.scss
+++ b/theme/padplus/scss/post.scss
@@ -1,15 +1,15 @@
 // Post SCSS is useful for defining full CSS rules. Because they are included last, they override any previous matching selector with the same specificity.
 
 // Common
-@import 'post/typography.scss';
 @import 'post/focus.scss';
+@import 'post/typography.scss';
 
 // Components
+@import 'post/components/breadcrumbs.scss';
 @import 'post/components/buttons.scss';
 @import 'post/components/searchbar.scss';
-@import 'post/components/breadcrumbs.scss';
 
 // Layouts
+@import 'post/layouts/footer.scss';
 @import 'post/layouts/navbar.scss';
 @import 'post/layouts/sidebar.scss';
-@import 'post/layouts/footer.scss';

--- a/theme/padplus/scss/post.scss
+++ b/theme/padplus/scss/post.scss
@@ -7,6 +7,7 @@
 // Components
 @import 'post/components/breadcrumbs.scss';
 @import 'post/components/buttons.scss';
+@import 'post/components/dropdown.scss';
 @import 'post/components/searchbar.scss';
 
 // Layouts

--- a/theme/padplus/scss/post/components/_dropdown.scss
+++ b/theme/padplus/scss/post/components/_dropdown.scss
@@ -1,0 +1,31 @@
+// Make links in a menu clickable anywhere in the row.
+.dropdown-item {
+    a {
+        display: block;
+        width: 100%;
+        color: $body-color;
+    }
+    &:active,
+    &:hover,
+    &:focus,
+    &:focus-within {
+        outline: 0;
+        background-color: $dropdown-link-active-bg;
+        color: $dropdown-link-active-color;
+        a {
+            color: $dropdown-link-active-color;
+        }
+    }
+    &[aria-current="true"] {
+        position: relative;
+        display: flex;
+        align-items: center;
+        &:before {
+            @include fa-icon();
+            content: $fa-var-circle;
+            position: absolute;
+            left: 0.4rem;
+            font-size: 0.7rem;
+        }
+    }
+}

--- a/theme/padplus/scss/post/components/_dropdown.scss
+++ b/theme/padplus/scss/post/components/_dropdown.scss
@@ -1,3 +1,4 @@
+// Copy dropdown rule from moodle/core.scss to fix fa-icon mixin inclusion from Font Awesome 5.
 // Make links in a menu clickable anywhere in the row.
 .dropdown-item {
     a {
@@ -22,10 +23,12 @@
         align-items: center;
         &:before {
             @include fa-icon();
-            content: $fa-var-circle;
+            font-family: 'Font Awesome 5 Free';
+            font-weight: 900;
+            content: fa-content($fa-var-check);
             position: absolute;
             left: 0.4rem;
-            font-size: 0.7rem;
+            font-size: 0.8rem;
         }
     }
 }


### PR DESCRIPTION
Migration from Font Awesome 4 to 5 implies some changes in when using `fa-icon` mixin in a pseudo-element :
- see https://fontawesome.com/v5.15/how-to-use/on-the-web/setup/upgrading-from-version-4#manually
- more specifically step 6, add font-family and font-weight

**This is a fix for the dropdown item style, which uses this feature for selected item.**

Other elements may be impacted, but we can take care later. See details there https://3.basecamp.com/5191032/buckets/24030658/todos/4540851400