### PR TITLE
Pad dashboard

### DIFF
--- a/theme/padplus/config.php
+++ b/theme/padplus/config.php
@@ -70,3 +70,15 @@ $THEME->addblockposition = BLOCK_ADDBLOCK_POSITION_FLATNAV;
 $THEME->scss = function($theme) {
     return theme_padplus_get_main_scss_content($theme);
 };
+
+
+$THEME->layouts = [
+    // Override mydashboard layout from Boost:
+    // set nocontextheader to false to display page header on dashboard.
+    'mydashboard' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true, 'langmenu' => true, 'nocontextheader' => false)
+    )
+];

--- a/theme/padplus/lang/en/theme_padplus.php
+++ b/theme/padplus/lang/en/theme_padplus.php
@@ -32,6 +32,7 @@ $string['region-side-pre'] = 'Right';
 
 $string['aria-main-nav'] = 'Main navigation';
 $string['allcourses-menu'] = 'All courses';
+$string['myhome-welcome'] = 'Welcome {$a}';
 
 // Theme settings strings.
 $string['settings-color-title'] = 'Theme colours';

--- a/theme/padplus/lang/fr/theme_padplus.php
+++ b/theme/padplus/lang/fr/theme_padplus.php
@@ -32,6 +32,7 @@ $string['region-side-pre'] = 'Droit';
 
 $string['aria-main-nav'] = 'Navigation principale';
 $string['allcourses-menu'] = 'Tous les cours';
+$string['myhome-welcome'] = 'Bienvenue  {$a}';
 
 // Theme settings strings.
 $string['settings-color-title'] = 'Couleurs du thème';

--- a/theme/padplus/renderers.php
+++ b/theme/padplus/renderers.php
@@ -213,4 +213,28 @@ class theme_padplus_core_renderer extends core_renderer {
         );
     }
 
+    private function is_dashboard_page() {
+        $pagepath = $this->page->url->get_path();
+        return $pagepath === '/my/index.php';
+    }
+
+    /*** PADPLUS: override dashboard title for consistency and custom heading */
+    public function page_title() {
+        global $SITE;
+        if ($this->is_dashboard_page()) {
+            $strmymoodle = get_string('myhome');
+            return "$SITE->shortname: $strmymoodle";
+        }
+        return $this->page->title;
+    }
+
+    public function context_header($headerinfo = null, $headinglevel = 1) {
+        global $USER;
+        if ($this->is_dashboard_page()) {
+            $this->page->set_heading(get_string('myhome-welcome', 'theme_padplus', $USER->firstname));
+        }
+        return parent::context_header($headerinfo, $headinglevel);
+    }
+    /*** PADPLUS END */
+
 }

--- a/theme/padplus/scss/post.scss
+++ b/theme/padplus/scss/post.scss
@@ -14,3 +14,6 @@
 @import 'post/layouts/footer.scss';
 @import 'post/layouts/navbar.scss';
 @import 'post/layouts/sidebar.scss';
+
+// Pages
+@import 'post/pages/dashboard.scss';

--- a/theme/padplus/scss/post.scss
+++ b/theme/padplus/scss/post.scss
@@ -5,8 +5,10 @@
 @import 'post/typography.scss';
 
 // Components
+@import 'post/components/badges.scss';
 @import 'post/components/breadcrumbs.scss';
 @import 'post/components/buttons.scss';
+@import 'post/components/course-cards.scss';
 @import 'post/components/dropdown.scss';
 @import 'post/components/searchbar.scss';
 

--- a/theme/padplus/scss/post/components/_badges.scss
+++ b/theme/padplus/scss/post/components/_badges.scss
@@ -1,0 +1,11 @@
+.badge-info-pad {
+    align-items: center;
+    background-color: $gray-300;
+    border-radius: 4px;
+    color: $body-color;
+    display: flex;
+    font-size: $pad-mention-size;
+    font-weight: 400;
+    height: 26px;
+    padding: 4px 8px;
+}

--- a/theme/padplus/scss/post/components/_buttons.scss
+++ b/theme/padplus/scss/post/components/_buttons.scss
@@ -31,7 +31,6 @@
     border: 1px solid theme-color("pad-link");
     border-radius: 4px;
     color: theme-color("pad-link");
-    margin-left: 22px;
     &:hover {
         background-color: theme-color("pad-btn-secondary-bg");
     }

--- a/theme/padplus/scss/post/components/_course-cards.scss
+++ b/theme/padplus/scss/post/components/_course-cards.scss
@@ -1,0 +1,162 @@
+.dashboard-card-deck {
+    margin-top: 20px;
+}
+
+.block-recentlyaccessedcourses {
+    .dashboard-card-deck {
+        background-color: $light;
+        border-radius: 8px;
+        padding-top: 30px;
+        padding-bottom: 30px;
+    }
+}
+
+.block-myoverview.block-cards {
+    .dropdown-toggle {
+        &:after {
+            margin-left: 10px;
+        }
+    }
+}
+
+// Card view
+.card .dashboard-card {
+    border: 1px solid theme-color("pad-border");
+    border-radius: 8px;
+    box-shadow: 0px 4px 4px 0px rgba(56, 69, 76, 0.04);
+    min-height: 275px;
+    overflow: hidden;
+    a:first-child {
+        padding: 16px 16px 0px 16px;
+    }
+    .course-info-container {
+        a {
+            color: theme-color("pad-link") !important;
+        }
+        padding: 16px;
+        button {
+            &:focus {
+                box-shadow: 0 0 0 0.2rem $gray-200;
+            }
+        }
+        button:last-child {
+            color:  theme-color("primary") !important;
+        }
+        .text-muted {
+            color: $body-color !important;
+            font-size: $font-size-sm;
+        }
+    }
+    // Progress bar
+    .dashboard-card-footer {
+        align-items: center;
+        display: flex;
+        padding: 16px;
+        .progress {
+            background-color:  theme-color("light") !important;
+            border: 0px solid transparent !important;
+            border-radius: 6px;
+            flex-grow: 1;
+            height: 12px !important;
+            .progress-bar {
+                border-radius: 6px;
+            }
+        }
+        .small {
+            font-size: $font-size-sm;
+            margin-left: 6px;
+            strong {
+                font-weight: normal !important;
+            }
+        }
+    }
+}
+
+// List view
+.dashboard-list-course-pad {
+    margin-top: 20px;
+    .list-group-item.course-listitem {
+        border: 1px solid theme-color("pad-border");
+        border-radius: 8px;
+        box-shadow: 0px 4px 4px 0px rgba(56, 69, 76, 0.04);
+        margin-bottom: 16px;
+        a {
+            color: theme-color("pad-link") !important;
+            &:focus {
+                background-color: transparent;
+            }
+        }
+        .text-muted {
+            color: $body-color !important;
+            font-size: $font-size-sm;
+            margin-bottom: 2px;
+        }
+        .badge-info-pad {
+            margin-top: 10px;
+        }
+        // Progress bar
+        .list-course-progress-container {
+            align-items: center;
+            display: flex;
+            margin-top: 10px;
+            width: 45%;
+            .progress {
+                background-color:  theme-color("light") !important;
+                border: 0px solid transparent !important;
+                border-radius: 6px;
+                flex-grow: 1;
+                height: 12px !important;
+                .progress-bar {
+                    border-radius: 6px;
+                }
+            }
+            .small {
+                font-size: $font-size-sm;
+                margin-left: 6px;
+                strong {
+                    font-weight: normal !important;
+                }
+            }
+        }
+        // Favourite icon
+        button {
+            &:focus {
+                box-shadow: 0 0 0 0.2rem $gray-200;
+            }
+        }
+        button:last-child {
+            color:  theme-color("primary") !important;
+        }
+    }
+}
+
+// The next class allows us to force the course title to two lines, however generating issues in the focus (also solved below)
+.dashboard-card-content-pad {
+    a {
+        span {
+            display: -webkit-box;
+            white-space: normal;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+        }
+        &:focus {
+            box-shadow: none !important;
+            span {
+                box-shadow: inset 0 0 0 .2rem theme-color("primary") !important;
+            }
+        }
+    }
+}
+
+// Dashboard pagination icons
+.block-recentlyaccessedcourses .pagination {
+    li {
+        a {
+            border-radius: 4px;
+            padding: 4px 6px;
+        }
+    }
+    li:last-child {
+        margin-left: 8px;
+    }
+}

--- a/theme/padplus/scss/post/components/_dropdown.scss
+++ b/theme/padplus/scss/post/components/_dropdown.scss
@@ -1,5 +1,11 @@
 // Copy dropdown rule from moodle/core.scss to fix fa-icon mixin inclusion from Font Awesome 5.
 // Make links in a menu clickable anywhere in the row.
+.dropdown-menu {
+    border: 1px solid theme-color("pad-border");
+    border-radius: 4px;
+    box-shadow: 0px 4px 4px 0px rgba(56, 69, 76, 0.04);
+}
+
 .dropdown-item {
     a {
         display: block;
@@ -11,7 +17,8 @@
     &:focus,
     &:focus-within {
         outline: 0;
-        background-color: $dropdown-link-active-bg;
+        background-color: theme-color("pad-link");
+        box-shadow: none !important;
         color: $dropdown-link-active-color;
         a {
             color: $dropdown-link-active-color;
@@ -30,5 +37,25 @@
             left: 0.4rem;
             font-size: 0.8rem;
         }
+    }
+}
+
+.dropdown-toggle {
+    display: flex;
+    align-items: center;
+    &:after {
+        border: none;
+        content: fa-content($fa-var-chevron-down);
+        @include fa-icon();
+        font-family: 'Font Awesome 5 Free';
+        font-weight: 900;
+    }
+}
+
+// Navbar dropdown
+.nav.usernav .usermenu .dropdown-toggle {
+    display: flex !important;
+    &:after {
+        color: $black;
     }
 }

--- a/theme/padplus/scss/post/pages/_dashboard.scss
+++ b/theme/padplus/scss/post/pages/_dashboard.scss
@@ -1,0 +1,22 @@
+// Override dashboard style (/my/index page)
+#page {
+    background-color: $white;
+}
+
+.card {
+    border: none;
+}
+
+#page-my-index {
+    // hide avater and messaging button in My Dashboard header
+    .page-header-image,
+    .header-button-group {
+        display: none;
+    }
+
+    #page-header {
+        .btn-secondary {
+            margin-left: 22px;
+        }
+    }
+}

--- a/theme/padplus/scss/post/pages/_dashboard.scss
+++ b/theme/padplus/scss/post/pages/_dashboard.scss
@@ -19,4 +19,35 @@
             margin-left: 22px;
         }
     }
+
+    #upcoming-events-date {
+        color: $secondary;
+        font-size: $pad-mention-size;
+        font-weight: 400;
+        margin-bottom: 16px;
+        a {
+            color: theme-color("primary") !important;
+            font-size: $pad-mention-size;
+            font-weight: 700;
+        }
+    }
+
+    .card-text.content.calendarwrapper {
+        border: 1px #E5E5E5 solid;
+        border-radius: 8px;
+        box-shadow: 0px 8px 8px 0px rgba(56, 69, 76, 0.04);
+        padding: 24px 16px;
+        margin-bottom: 16px;
+        div:last-child hr {
+            display: none;
+        }
+        .icon {
+            color: $secondary;
+        }
+    }
+
+    .footer .gotocal {
+        display: flex;
+        justify-content: flex-end;
+    }
 }

--- a/theme/padplus/templates/block_myoverview/course-action-menu.mustache
+++ b/theme/padplus/templates/block_myoverview/course-action-menu.mustache
@@ -1,0 +1,80 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/course-action-menu
+
+    This template renders action menu for each course.
+
+    Example context (json):
+    {
+        "isfavourite": true
+    }
+}}
+<div class="ml-auto dropdown">
+    <button class="btn btn-link btn-icon icon-size-3 coursemenubtn"
+        type="button"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false">
+        {{#pix}} i/moremenu, core {{/pix}}
+            <span class="sr-only">
+                {{#str}} aria:courseactions, block_myoverview {{/str}} {{{fullname}}}
+            </span>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right">
+        <a class="dropdown-item {{#isfavourite}}hidden{{/isfavourite}}" href="#"
+            data-action="add-favourite"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} addtofavourites, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:addtofavourites, block_myoverview {{/str}} {{{fullname}}}
+            </div>
+        </a>
+        <a class="dropdown-item {{^isfavourite}}hidden{{/isfavourite}}" href="#"
+            data-action="remove-favourite"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} removefromfavourites, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:removefromfavourites, block_myoverview {{/str}} {{{fullname}}}
+            </div>
+        </a>
+        <a class="dropdown-item {{^hidden}}hidden{{/hidden}}" href="#"
+            data-action="show-course"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} show, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:showcourse, block_myoverview, {{fullname}} {{/str}}
+            </div>
+        </a>
+        <a class="dropdown-item {{#hidden}}hidden{{/hidden}}" href="#"
+            data-action="hide-course"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} hidecourse, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:hidecourse, block_myoverview, {{fullname}} {{/str}}
+            </div>
+        </a>
+    </div>
+</div>

--- a/theme/padplus/templates/block_myoverview/course-action-menu.mustache
+++ b/theme/padplus/templates/block_myoverview/course-action-menu.mustache
@@ -21,60 +21,44 @@
 
     Example context (json):
     {
+        "id": 3,
         "isfavourite": true
     }
 }}
-<div class="ml-auto dropdown">
-    <button class="btn btn-link btn-icon icon-size-3 coursemenubtn"
-        type="button"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        aria-expanded="false">
-        {{#pix}} i/moremenu, core {{/pix}}
-            <span class="sr-only">
-                {{#str}} aria:courseactions, block_myoverview {{/str}} {{{fullname}}}
-            </span>
-    </button>
-    <div class="dropdown-menu dropdown-menu-right">
-        <a class="dropdown-item {{#isfavourite}}hidden{{/isfavourite}}" href="#"
-            data-action="add-favourite"
-            data-course-id="{{id}}"
-            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+<div class="ml-auto">
+    {{! modified template core_course/favouriteicon (without the icon) }}
+    <span id="favorite-icon-{{ id }}-{{ uniqid }}"
+        data-region="favourite-icon"
+        data-course-id="{{id}}"
+        >
+        <span
+            class="sr-only {{^isfavourite}}hidden{{/isfavourite}}"
+            data-region="is-favourite"
+            aria-hidden="{{^isfavourite}}true{{/isfavourite}}{{#isfavourite}}false{{/isfavourite}}"
             >
-            {{#str}} addtofavourites, block_myoverview {{/str}}
+            {{#str}} aria:favourite, core_course {{/str}}
+        </span>
+    </span>
+    <button class="btn btn-link btn-icon icon-size-3 coursemenubtn {{#isfavourite}}hidden{{/isfavourite}}"
+        type="button"
+        title="{{#str}} aria:addtofavourites, block_myoverview {{/str}}"
+        data-action="add-favourite"
+        data-course-id="{{id}}"
+        aria-controls="favorite-icon-{{ id }}-{{ uniqid }}">
+            {{#pix}} i/star-o, core {{/pix}}
             <div class="sr-only">
                 {{#str}} aria:addtofavourites, block_myoverview {{/str}} {{{fullname}}}
             </div>
-        </a>
-        <a class="dropdown-item {{^isfavourite}}hidden{{/isfavourite}}" href="#"
-            data-action="remove-favourite"
-            data-course-id="{{id}}"
-            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
-            >
-            {{#str}} removefromfavourites, block_myoverview {{/str}}
+    </button>
+    <button class="btn btn-link btn-icon icon-size-3 coursemenubtn {{^isfavourite}}hidden{{/isfavourite}}"
+        type="button"
+        title="{{#str}} aria:removefromfavourites, block_myoverview {{/str}}"
+        data-action="remove-favourite"
+        data-course-id="{{id}}"
+        aria-controls="favorite-icon-{{ id }}-{{ uniqid }}">
+            {{#pix}} i/star, core {{/pix}}
             <div class="sr-only">
                 {{#str}} aria:removefromfavourites, block_myoverview {{/str}} {{{fullname}}}
             </div>
-        </a>
-        <a class="dropdown-item {{^hidden}}hidden{{/hidden}}" href="#"
-            data-action="show-course"
-            data-course-id="{{id}}"
-            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
-            >
-            {{#str}} show, block_myoverview {{/str}}
-            <div class="sr-only">
-                {{#str}} aria:showcourse, block_myoverview, {{fullname}} {{/str}}
-            </div>
-        </a>
-        <a class="dropdown-item {{#hidden}}hidden{{/hidden}}" href="#"
-            data-action="hide-course"
-            data-course-id="{{id}}"
-            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
-            >
-            {{#str}} hidecourse, block_myoverview {{/str}}
-            <div class="sr-only">
-                {{#str}} aria:hidecourse, block_myoverview, {{fullname}} {{/str}}
-            </div>
-        </a>
-    </div>
+    </button>
 </div>

--- a/theme/padplus/templates/block_myoverview/main.mustache
+++ b/theme/padplus/templates/block_myoverview/main.mustache
@@ -1,0 +1,54 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/main
+
+    This template renders the main content area for the myoverview block.
+
+    Example context (json):
+    {}
+}}
+
+<div id="block-myoverview-{{uniqid}}" class="block-myoverview block-cards" data-region="myoverview" role="navigation">
+
+            <div data-region="filter" class="d-flex align-items-center flex-wrap" aria-label="{{#str}} aria:controls, block_myoverview {{/str}}">
+                {{> block_myoverview/nav-grouping-selector }}
+
+                {{> block_myoverview/nav-sort-selector }}
+                {{#displaydropdown}}
+                    {{> block_myoverview/nav-display-selector }}
+                {{/displaydropdown}}
+            </div>
+
+    <div class="container-fluid p-0">
+        {{> block_myoverview/courses-view }}
+    </div>
+</div>
+{{#js}}
+require(
+[
+    'jquery',
+    'block_myoverview/main',
+],
+function(
+    $,
+    Main
+) {
+    var root = $('#block-myoverview-{{uniqid}}');
+    Main.init(root);
+});
+{{/js}}

--- a/theme/padplus/templates/block_myoverview/main.mustache
+++ b/theme/padplus/templates/block_myoverview/main.mustache
@@ -28,7 +28,6 @@
             <div data-region="filter" class="d-flex align-items-center flex-wrap" aria-label="{{#str}} aria:controls, block_myoverview {{/str}}">
                 {{> block_myoverview/nav-grouping-selector }}
 
-                {{> block_myoverview/nav-sort-selector }}
                 {{#displaydropdown}}
                     {{> block_myoverview/nav-display-selector }}
                 {{/displaydropdown}}

--- a/theme/padplus/templates/block_myoverview/nav-display-selector.mustache
+++ b/theme/padplus/templates/block_myoverview/nav-display-selector.mustache
@@ -1,0 +1,48 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/nav-display-selector
+
+    This template renders display dropdown.
+
+    Example context (json):
+    {
+        "cards": true,
+        "list": false,
+        "summary": false
+    }
+}}
+<div class="dropdown mb-1">
+    <button id="displaydropdown" type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+    aria-label="{{#str}} aria:displaydropdown, block_myoverview {{/str}}">
+        {{#pix}} a/view_icon_active {{/pix}}
+        <span class="d-sm-inline-block" data-active-item-text>
+            {{#card}}{{#str}} card, block_myoverview {{/str}}{{/card}}
+            {{#list}}{{#str}} list, block_myoverview {{/str}}{{/list}}
+            {{#summary}}{{#str}} summary, block_myoverview {{/str}}{{/summary}}
+        </span>
+    </button>
+    <ul class="dropdown-menu" role="menu" data-show-active-item data-skip-active-class="true" aria-labelledby="displaydropdown">
+    {{#layouts}}
+            <li>
+                <a class="dropdown-item" href="#" data-display-option="display" data-value="{{id}}" data-pref="{{id}}" aria-label="{{arialabel}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#active}}aria-current="true"{{/active}}>
+                    {{name}}
+                </a>
+            </li>
+    {{/layouts}}
+    </ul>
+</div>

--- a/theme/padplus/templates/block_myoverview/nav-display-selector.mustache
+++ b/theme/padplus/templates/block_myoverview/nav-display-selector.mustache
@@ -29,7 +29,6 @@
 <div class="dropdown mb-1">
     <button id="displaydropdown" type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     aria-label="{{#str}} aria:displaydropdown, block_myoverview {{/str}}">
-        {{#pix}} a/view_icon_active {{/pix}}
         <span class="d-sm-inline-block" data-active-item-text>
             {{#card}}{{#str}} card, block_myoverview {{/str}}{{/card}}
             {{#list}}{{#str}} list, block_myoverview {{/str}}{{/list}}

--- a/theme/padplus/templates/block_myoverview/nav-grouping-selector.mustache
+++ b/theme/padplus/templates/block_myoverview/nav-grouping-selector.mustache
@@ -1,0 +1,151 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/nav-grouping-selector
+
+    This template renders grouping dropdown.
+
+    Example context (json):
+    {
+        "allincludinghidden": false,
+        "all": true,
+        "inprogress": false,
+        "future": false,
+        "past": false,
+        "favourites": false,
+        "hidden": false,
+        "displaygroupingallincludinghidden": false,
+        "displaygroupingall": true,
+        "displaygroupinginprogress": true,
+        "displaygroupingfuture": true,
+        "displaygroupingpast": true,
+        "displaygroupingfavourites": true,
+        "displaygroupinghidden": true,
+        "displaygroupingselector": true
+    }
+}}
+{{#displaygroupingselector}}
+<div class="dropdown mb-1 mr-auto">
+    <button id="groupingdropdown" type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:groupingdropdown, block_myoverview {{/str}}">
+        {{#pix}} i/filter {{/pix}}
+        <span class="d-sm-inline-block" data-active-item-text>
+            {{#allincludinghidden}}{{#str}} allincludinghidden, block_myoverview {{/str}}{{/allincludinghidden}}
+            {{#all}}{{#str}} all, block_myoverview {{/str}}{{/all}}
+            {{#inprogress}}{{#str}} inprogress, block_myoverview {{/str}}{{/inprogress}}
+            {{#future}}{{#str}} future, block_myoverview {{/str}}{{/future}}
+            {{#past}}{{#str}} past, block_myoverview {{/str}}{{/past}}
+            {{#favourites}}{{#str}} favourites, block_myoverview {{/str}}{{/favourites}}
+            {{#hidden}}{{#str}} hiddencourses, block_myoverview {{/str}}{{/hidden}}
+            {{selectedcustomfield}}
+        </span>
+    </button>
+    <ul class="dropdown-menu" role="menu" data-show-active-item data-skip-active-class="true" data-active-item-text aria-labelledby="groupingdropdown">
+        {{#displaygroupingallincludinghidden}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="allincludinghidden" data-pref="allincludinghidden" aria-label="{{#str}} aria:allcoursesincludinghidden, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#allincludinghidden}}aria-current="true"{{/allincludinghidden}}>
+                {{#str}} allincludinghidden, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingallincludinghidden}}
+        {{#displaygroupingall}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="all" data-pref="all" aria-label="{{#str}} aria:allcourses, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#all}}aria-current="true"{{/all}}>
+                {{#str}} all, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingall}}
+        {{#displaygroupinginprogress}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="inprogress" data-pref="inprogress" aria-label="{{#str}} aria:inprogress, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#inprogress}}aria-current="true"{{/inprogress}}>
+                {{#str}} inprogress, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupinginprogress}}
+        {{#displaygroupingfuture}}
+            {{^displaygroupinginprogress}}
+            <li class="dropdown-divider" role="presentation">
+                <span class="filler">&nbsp;</span>
+            </li>
+            {{/displaygroupinginprogress}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="future" data-pref="future" aria-label="{{#str}} aria:future, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#future}}aria-current="true"{{/future}}>
+                {{#str}} future, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingfuture}}
+        {{#displaygroupingpast}}
+            {{^displaygroupinginprogress}}
+                {{^displaygroupingfuture}}
+                <li class="dropdown-divider" role="presentation">
+                    <span class="filler">&nbsp;</span>
+                </li>
+                {{/displaygroupingfuture}}
+            {{/displaygroupinginprogress}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="past" data-pref="past" aria-label="{{#str}} aria:past, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#past}}aria-current="true"{{/past}}>
+                {{#str}} past, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingpast}}
+        {{#displaygroupingcustomfield}}
+            <li class="dropdown-divider" role="presentation">
+                <span class="filler">&nbsp;</span>
+            </li>
+            {{#customfieldvalues}}
+                <li>
+                    <a class="dropdown-item" href="#" data-filter="grouping"
+                       data-value="customfield" data-pref="customfield" data-customfieldvalue="{{value}}"
+                       aria-label="{{#str}}aria:customfield, block_myoverview, {{name}}{{/str}}"
+                       aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#active}}aria-current="true"{{/active}}>
+                        {{name}}
+                    </a>
+                </li>
+            {{/customfieldvalues}}
+        {{/displaygroupingcustomfield}}
+        {{#displaygroupingfavourites}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="favourites"  data-pref="favourites" aria-label="{{#str}} aria:favourites, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#favourites}}aria-current="true"{{/favourites}}>
+                {{#str}} favourites, block_myoverview {{/str}}
+            </a>
+        {{/displaygroupingfavourites}}
+        {{#displaygroupinghidden}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="hidden"  data-pref="hidden" aria-label="{{#str}} aria:hiddencourses, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#hidden}}aria-current="true"{{/hidden}}>
+                {{#str}} hiddencourses, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupinghidden}}
+    </ul>
+</div>
+{{/displaygroupingselector}}
+{{^displaygroupingselector}}
+<div class="mb-1 mr-auto">
+    <span class="filler">&nbsp;</span>
+</div>
+{{/displaygroupingselector}}

--- a/theme/padplus/templates/block_myoverview/nav-grouping-selector.mustache
+++ b/theme/padplus/templates/block_myoverview/nav-grouping-selector.mustache
@@ -41,7 +41,6 @@
 {{#displaygroupingselector}}
 <div class="dropdown mb-1 mr-auto">
     <button id="groupingdropdown" type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:groupingdropdown, block_myoverview {{/str}}">
-        {{#pix}} i/filter {{/pix}}
         <span class="d-sm-inline-block" data-active-item-text>
             {{#allincludinghidden}}{{#str}} allincludinghidden, block_myoverview {{/str}}{{/allincludinghidden}}
             {{#all}}{{#str}} all, block_myoverview {{/str}}{{/all}}

--- a/theme/padplus/templates/block_myoverview/view-list.mustache
+++ b/theme/padplus/templates/block_myoverview/view-list.mustache
@@ -1,0 +1,91 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/view-list
+
+    This template renders the list view for the myoverview block.
+
+    Example context (json):
+    {
+        "courses": [
+            {
+                "name": "Assignment due 1",
+                "viewurl": "https://moodlesite/course/view.php?id=2",
+                "courseimage": "https://moodlesite/pluginfile/123/course/overviewfiles/123.jpg",
+                "fullname": "course 3",
+                "hasprogress": true,
+                "progress": 10,
+                "coursecategory": "Miscellaneous",
+                "visible": true
+            }
+        ]
+    }
+}}
+
+<ul class="list-group">
+{{#courses}}
+    <li class="list-group-item course-listitem"
+        data-region="course-content"
+        data-course-id="{{{id}}}">
+        <div class="row">
+            <div class="{{#hasprogress}}col-md-6{{/hasprogress}}{{^hasprogress}}col-md-11 col-md-11{{/hasprogress}} d-flex align-items-center">
+                <div>
+                    <div class="text-muted muted d-flex flex-wrap">
+                        {{#showcoursecategory}}
+                            <span class="sr-only">
+                                {{#str}}aria:coursecategory, core_course{{/str}}
+                            </span>
+                            <span class="categoryname">
+                                {{{coursecategory}}}
+                            </span>
+                        {{/showcoursecategory}}
+                        {{#showshortname}}
+                            {{#showcoursecategory}}
+                                <div class="pl-1 pr-1">|</div>
+                            {{/showcoursecategory}}
+                        <span class="sr-only">
+                            {{#str}}aria:courseshortname, core_course{{/str}}
+                        </span>
+                        <div>{{{shortname}}}</div>
+                        {{/showshortname}}
+                    </div>
+                    <a href="{{viewurl}}" class="aalink coursename">
+                        {{> core_course/favouriteicon }}
+                        <span class="sr-only">
+                            {{#str}}aria:coursename, core_course{{/str}}
+                        </span>
+                        {{{fullname}}}
+                    </a>
+                    {{^visible}}
+                        <div class="d-flex flex-wrap">
+                            <span class="badge badge-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                        </div>
+                    {{/visible}}
+                </div>
+            </div>
+            {{#hasprogress}}
+            <div class="col-md-5 pt-1">
+                {{> block_myoverview/progress-bar}}
+            </div>
+            {{/hasprogress}}
+            <div class="col-md-1 p-0 d-flex">
+                {{> block_myoverview/course-action-menu }}
+            </div>
+        </div>
+    </li>
+{{/courses}}
+</ul>

--- a/theme/padplus/templates/block_myoverview/view-list.mustache
+++ b/theme/padplus/templates/block_myoverview/view-list.mustache
@@ -36,13 +36,13 @@
     }
 }}
 
-<ul class="list-group">
+<ul class="list-group dashboard-list-course-pad">
 {{#courses}}
     <li class="list-group-item course-listitem"
         data-region="course-content"
         data-course-id="{{{id}}}">
         <div class="row">
-            <div class="{{#hasprogress}}col-md-6{{/hasprogress}}{{^hasprogress}}col-md-11 col-md-11{{/hasprogress}} d-flex align-items-center">
+            <div class="col-md-11 col-md-11 d-flex align-items-center">
                 <div>
                     <div class="text-muted muted d-flex flex-wrap">
                         {{#showcoursecategory}}
@@ -64,7 +64,6 @@
                         {{/showshortname}}
                     </div>
                     <a href="{{viewurl}}" class="aalink coursename">
-                        {{> core_course/favouriteicon }}
                         <span class="sr-only">
                             {{#str}}aria:coursename, core_course{{/str}}
                         </span>
@@ -72,20 +71,20 @@
                     </a>
                     {{^visible}}
                         <div class="d-flex flex-wrap">
-                            <span class="badge badge-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                            <span class="badge badge-info badge-info-pad">{{#str}} hiddenfromstudents {{/str}}</span>
                         </div>
                     {{/visible}}
                 </div>
             </div>
-            {{#hasprogress}}
-            <div class="col-md-5 pt-1">
-                {{> block_myoverview/progress-bar}}
-            </div>
-            {{/hasprogress}}
             <div class="col-md-1 p-0 d-flex">
                 {{> block_myoverview/course-action-menu }}
             </div>
         </div>
+        {{#hasprogress}}
+            <div class="list-course-progress-container">
+                {{> block_myoverview/progress-bar}}
+            </div>
+        {{/hasprogress}}
     </li>
 {{/courses}}
 </ul>

--- a/theme/padplus/templates/core/block.mustache
+++ b/theme/padplus/templates/core/block.mustache
@@ -1,0 +1,64 @@
+{{!
+    @template core/block
+
+    Example context (json):
+    {
+        "id": "block0",
+        "class": "block block_html",
+        "showskiplink": true,
+        "type": "html",
+        "ariarole": "complementary",
+        "title": "Test block",
+        "blockinstanceid": 1,
+        "content": "<p>Hello block world!</p>"
+    }
+
+}}
+{{! Block Skip Link }}
+{{#showskiplink}}
+  <a href="#sb-{{skipid}}" class="sr-only sr-only-focusable">{{#str}}skipa, access, {{{title}}}{{/str}}</a>
+{{/showskiplink}}
+
+{{! Start Block Container }}
+<section id="{{id}}"
+     class="{{#hidden}}hidden{{/hidden}} {{class}} {{#hascontrols}}block_with_controls{{/hascontrols}} card mb-3"
+     role="{{ariarole}}"
+     data-block="{{type}}"
+     {{#arialabel}}
+        aria-label={{#quote}}{{{arialabel}}}{{/quote}}
+     {{/arialabel}}
+     {{^arialabel}}
+        {{#title}}
+          aria-labelledby="instance-{{blockinstanceid}}-header"
+        {{/title}}
+     {{/arialabel}}>
+
+    {{! Block contents }}
+    <div class="card-body p-3">
+
+        {{! Block header }}
+        {{#title}}
+            <h5 id="instance-{{blockinstanceid}}-header" class="card-title d-inline">{{{title}}}</h5>
+        {{/title}}
+
+        {{#hascontrols}}
+            <div class="block-controls float-right header">
+                {{{controls}}}
+            </div>
+        {{/hascontrols}}
+
+        <div class="card-text content mt-3">
+            {{{content}}}
+            <div class="footer">{{{footer}}}</div>
+            {{{annotation}}}
+        </div>
+
+    </div>
+
+{{! End Block Container }}
+</section>
+
+{{! Block Skip Link Target }}
+{{#showskiplink}}
+  <span id="sb-{{skipid}}"></span>
+{{/showskiplink}}

--- a/theme/padplus/templates/core/block.mustache
+++ b/theme/padplus/templates/core/block.mustache
@@ -38,7 +38,7 @@
 
         {{! Block header }}
         {{#title}}
-            <h5 id="instance-{{blockinstanceid}}-header" class="card-title d-inline">{{{title}}}</h5>
+            <h3 id="instance-{{blockinstanceid}}-header" class="card-title d-inline">{{{title}}}</h3>
         {{/title}}
 
         {{#hascontrols}}

--- a/theme/padplus/templates/core_calendar/upcoming_mini.mustache
+++ b/theme/padplus/templates/core_calendar/upcoming_mini.mustache
@@ -1,0 +1,101 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template calendar/upcoming_mini
+
+    Calendar upcoming view for blocks.
+
+    The purpose of this template is to render the upcoming view for blocks.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Example context (json):
+    {
+    }
+}}
+<div class="card-text content calendarwrapper"{{!
+    }} id="month-upcoming-mini-{{uniqid}}"{{!
+    }} data-context-id="{{defaulteventcontext}}"{{!
+    }} data-courseid="{{courseid}}"{{!
+    }} data-categoryid="{{categoryid}}"{{!
+}}>
+    {{> core/overlay_loading}}
+    {{#events}}
+        <div{{!
+            }} class="event"{{!
+            }} data-eventtype-{{normalisedeventtype}}="1"{{!
+            }} data-region="event-item"{{!
+        }}>
+            <span>{{#icon}}{{#pix}} {{key}}, {{component}}, {{alttext}} {{/pix}}{{/icon}}</span>
+            <a{{!
+                }} data-type="event"{{!
+                }} data-action="view-event"{{!
+                }} data-event-id="{{id}}"{{!
+                }} href="{{viewurl}}"{{!
+            }}>{{{name}}}</a>
+            <div class="date">{{{formattedtime}}}</div>
+            <hr>
+        </div>
+    {{/events}}
+    {{^events}}
+        {{#str}}noupcomingevents, calendar{{/str}}
+    {{/events}}
+</div>
+{{#js}}
+require([
+    'jquery',
+    'core_calendar/selectors',
+    'core_calendar/events',
+], function(
+    $,
+    CalendarSelectors,
+    CalendarEvents
+) {
+    var root = $('#month-upcoming-mini-{{uniqid}}');
+
+    $('body').on(CalendarEvents.filterChanged, function(e, data) {
+        M.util.js_pending("month-upcoming-mini-{{uniqid}}-filterChanged");
+
+        // A filter value has been changed.
+        // Find all matching cells in the popover data, and hide them.
+        var target = $("#month-upcoming-mini-{{uniqid}}").find(CalendarSelectors.eventType[data.type]);
+
+        var transitionPromise = $.Deferred();
+        if (data.hidden) {
+            transitionPromise.then(function() {
+                return target.slideUp('fast').promise();
+            });
+        } else {
+            transitionPromise.then(function() {
+                return target.slideDown('fast').promise();
+            });
+        }
+
+        transitionPromise.then(function() {
+            M.util.js_complete("month-upcoming-mini-{{uniqid}}-filterChanged");
+
+            return;
+        });
+
+        transitionPromise.resolve();
+    });
+});
+{{/js}}

--- a/theme/padplus/templates/core_calendar/upcoming_mini.mustache
+++ b/theme/padplus/templates/core_calendar/upcoming_mini.mustache
@@ -44,6 +44,7 @@
             }} data-eventtype-{{normalisedeventtype}}="1"{{!
             }} data-region="event-item"{{!
         }}>
+            <div class="date" id="upcoming-events-date">{{{formattedtime}}}</div>
             <span>{{#icon}}{{#pix}} {{key}}, {{component}}, {{alttext}} {{/pix}}{{/icon}}</span>
             <a{{!
                 }} data-type="event"{{!
@@ -51,7 +52,6 @@
                 }} data-event-id="{{id}}"{{!
                 }} href="{{viewurl}}"{{!
             }}>{{{name}}}</a>
-            <div class="date">{{{formattedtime}}}</div>
             <hr>
         </div>
     {{/events}}

--- a/theme/padplus/templates/core_course/coursecard.mustache
+++ b/theme/padplus/templates/core_course/coursecard.mustache
@@ -1,0 +1,77 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template course_course/coursecard
+
+    This template renders the a card for the course cards.
+
+    Example context (json):
+    {
+        "courses": [
+            {
+                "name": "Assignment due 1",
+                "viewurl": "https://moodlesite/course/view.php?id=2",
+                "courseimage": "https://moodlesite/pluginfile/123/course/overviewfiles/123.jpg",
+                "fullname": "course 3",
+                "hasprogress": true,
+                "progress": 10,
+                "visible": true
+            }
+        ]
+    }
+}}
+<div class="card dashboard-card" role="listitem"
+    data-region="course-content"
+    data-course-id="{{{id}}}">
+    <a href="{{viewurl}}" tabindex="-1">
+        <div class="card-img dashboard-card-img" style='background-image: url("{{{courseimage}}}");'>
+            <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
+        </div>
+    </a>
+    <div class="card-body pr-1 course-info-container" id="course-info-container-{{id}}-{{uniqid}}">
+        <div class="d-flex align-items-start">
+            <div class="w-100 text-truncate">
+                <div class="text-muted muted d-flex mb-1 flex-wrap">
+                    {{$coursecategory}}{{/coursecategory}}
+                    {{#showshortname}}
+                    {{$divider}}{{/divider}}
+                    <span class="sr-only">
+                        {{#str}}aria:courseshortname, core_course{{/str}}
+                    </span>
+                    <div>
+                        {{{shortname}}}
+                    </div>
+                    {{/showshortname}}
+                </div>
+                <a href="{{viewurl}}" class="aalink coursename mr-2">
+                    {{> core_course/favouriteicon }}
+                    <span class="sr-only">
+                            {{#str}}aria:coursename, core_course{{/str}}
+                        </span>
+                    {{$coursename}}{{/coursename}}
+                </a>
+                {{^visible}}
+                    <div class="d-flex flex-wrap">
+                        <span class="badge badge-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                    </div>
+                {{/visible}}
+            </div>
+            {{$menu}}{{/menu}}
+        </div>
+    </div>
+    {{$progress}}{{/progress}}
+</div>

--- a/theme/padplus/templates/core_course/coursecard.mustache
+++ b/theme/padplus/templates/core_course/coursecard.mustache
@@ -37,14 +37,14 @@
 <div class="card dashboard-card" role="listitem"
     data-region="course-content"
     data-course-id="{{{id}}}">
-    <a href="{{viewurl}}" tabindex="-1">
+    <a href="{{viewurl}}" title="{{fullname}}" tabindex="-1">
         <div class="card-img dashboard-card-img" style='background-image: url("{{{courseimage}}}");'>
-            <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
+            <span class="sr-only">{{fullname}}</span>
         </div>
     </a>
     <div class="card-body pr-1 course-info-container" id="course-info-container-{{id}}-{{uniqid}}">
         <div class="d-flex align-items-start">
-            <div class="w-100 text-truncate">
+            <div class="w-100 text-truncate dashboard-card-content-pad">
                 <div class="text-muted muted d-flex mb-1 flex-wrap">
                     {{$coursecategory}}{{/coursecategory}}
                     {{#showshortname}}
@@ -58,7 +58,6 @@
                     {{/showshortname}}
                 </div>
                 <a href="{{viewurl}}" class="aalink coursename mr-2">
-                    {{> core_course/favouriteicon }}
                     <span class="sr-only">
                             {{#str}}aria:coursename, core_course{{/str}}
                         </span>
@@ -66,7 +65,7 @@
                 </a>
                 {{^visible}}
                     <div class="d-flex flex-wrap">
-                        <span class="badge badge-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                        <span class="badge badge-info badge-info-pad">{{#str}} hiddenfromstudents {{/str}}</span>
                     </div>
                 {{/visible}}
             </div>


### PR DESCRIPTION
Fix for common dropdown style

Set dashboard headers and title

Styling course blocks on dashboard:
- override templates for course cards and list
- progression bar, favourite action, ...

Styling upcoming events block on dashboard
