### PR TITLE
Header design

### DIFF
--- a/theme/padplus/lang/en/theme_padplus.php
+++ b/theme/padplus/lang/en/theme_padplus.php
@@ -30,6 +30,7 @@ $string['pluginname'] = 'PAD+';
 // We need to include a lang string for each block region.
 $string['region-side-pre'] = 'Right';
 
+// Main strings.
 $string['global-search'] = 'Search for courses, people...';
 $string['aria-main-nav'] = 'Main navigation';
 $string['allcourses-menu'] = 'All courses';
@@ -58,3 +59,6 @@ $string['settings-privacylink'] = 'Privacy';
 $string['settings-privacylink-desc'] = 'URL to privacy terms PAD+';
 $string['settings-copyright'] = 'Copyright';
 $string['settings-copyright-desc'] = 'Footer information';
+
+// Enrolment strings.
+$string['unenrolme'] = 'Unenrol me';

--- a/theme/padplus/lang/fr/theme_padplus.php
+++ b/theme/padplus/lang/fr/theme_padplus.php
@@ -30,6 +30,7 @@ $string['pluginname'] = 'PAD+';
 // We need to include a lang string for each block region.
 $string['region-side-pre'] = 'Droit';
 
+// Main strings.
 $string['global-search'] = 'Rechercher des séquences, des personnes...';
 $string['aria-main-nav'] = 'Navigation principale';
 $string['allcourses-menu'] = 'Tous les cours';
@@ -58,3 +59,6 @@ $string['settings-privacylink'] = 'Politique de confidentialité';
 $string['settings-privacylink-desc'] = 'URL vers la politique de confidentialité PAD+';
 $string['settings-copyright'] = 'Copyright';
 $string['settings-copyright-desc'] = 'Information du pied de page';
+
+// Enrolment strings.
+$string['unenrolme'] = 'Me désinscrire';

--- a/theme/padplus/renderers.php
+++ b/theme/padplus/renderers.php
@@ -253,6 +253,100 @@ class theme_padplus_core_renderer extends core_renderer {
         }
         return parent::context_header($headerinfo, $headinglevel);
     }
+
+    public function context_header_settings_menu() {
+        $context = $this->page->context;
+        $menu = new action_menu();
+
+        $items = $this->page->navbar->get_items();
+        $currentnode = end($items);
+
+        $showcoursemenu = false;
+        $showfrontpagemenu = false;
+        $showusermenu = false;
+
+        // We are on the course home page.
+        if (($context->contextlevel == CONTEXT_COURSE) &&
+                !empty($currentnode) &&
+                ($currentnode->type == navigation_node::TYPE_COURSE || $currentnode->type == navigation_node::TYPE_SECTION)) {
+            $showcoursemenu = true;
+        }
+
+        $courseformat = course_get_format($this->page->course);
+        // This is a single activity course format, always show the course menu on the activity main page.
+        if ($context->contextlevel == CONTEXT_MODULE &&
+                !$courseformat->has_view_page()) {
+
+            $this->page->navigation->initialise();
+            $activenode = $this->page->navigation->find_active_node();
+            // If the settings menu has been forced then show the menu.
+            if ($this->page->is_settings_menu_forced()) {
+                $showcoursemenu = true;
+            } else if (!empty($activenode) && ($activenode->type == navigation_node::TYPE_ACTIVITY ||
+                            $activenode->type == navigation_node::TYPE_RESOURCE)) {
+
+                // We only want to show the menu on the first page of the activity. This means
+                // the breadcrumb has no additional nodes.
+                if ($currentnode && ($currentnode->key == $activenode->key && $currentnode->type == $activenode->type)) {
+                    $showcoursemenu = true;
+                }
+            }
+        }
+
+        // This is the site front page.
+        if ($context->contextlevel == CONTEXT_COURSE &&
+                !empty($currentnode) &&
+                $currentnode->key === 'home') {
+            $showfrontpagemenu = true;
+        }
+
+        // This is the user profile page.
+        if ($context->contextlevel == CONTEXT_USER &&
+                !empty($currentnode) &&
+                ($currentnode->key === 'myprofile')) {
+            $showusermenu = true;
+        }
+
+        if ($showfrontpagemenu) {
+            $settingsnode = $this->page->settingsnav->find('frontpage', navigation_node::TYPE_SETTING);
+            if ($settingsnode) {
+                // Build an action menu based on the visible nodes from this navigation tree.
+                $skipped = $this->build_action_menu_from_navigation($menu, $settingsnode, false, true);
+
+                // We only add a list to the full settings menu if we didn't include every node in the short menu.
+                if ($skipped) {
+                    $text = get_string('morenavigationlinks');
+                    $url = new moodle_url('/course/admin.php', array('courseid' => $this->page->course->id));
+                    $link = new action_link($url, $text, null, null, new pix_icon('t/edit', $text));
+                    $menu->add_secondary_action($link);
+                }
+            }
+        } else if ($showcoursemenu) {
+            $settingsnode = $this->page->settingsnav->find('courseadmin', navigation_node::TYPE_COURSE);
+            if ($settingsnode) {
+                // Build an action menu based on the visible nodes from this navigation tree.
+                $skipped = $this->build_action_menu_from_navigation($menu, $settingsnode, false, true);
+
+                // We only add a list to the full settings menu if we didn't include every node in the short menu.
+                if ($skipped) {
+                    $text = get_string('morenavigationlinks');
+                    $url = new moodle_url('/course/admin.php', array('courseid' => $this->page->course->id));
+                    $link = new action_link($url, $text, null, null, new pix_icon('t/edit', $text));
+                    $menu->add_secondary_action($link);
+                }
+            }
+        } else if ($showusermenu) {
+            // Get the course admin node from the settings navigation.
+            $settingsnode = $this->page->settingsnav->find('useraccount', navigation_node::TYPE_CONTAINER);
+            if ($settingsnode) {
+                // Build an action menu based on the visible nodes from this navigation tree.
+                $this->build_action_menu_from_navigation($menu, $settingsnode);
+            }
+        }
+
+        return $this->render($menu);
+    }
+
     /*** PADPLUS END */
 
 }

--- a/theme/padplus/scss/post/components/_breadcrumbs.scss
+++ b/theme/padplus/scss/post/components/_breadcrumbs.scss
@@ -5,3 +5,9 @@
 .current-breadcrumb-item {
     color: $body-color;
 }
+
+.breadcrumb-container {
+    border-bottom: 1px solid theme-color('pad-border');
+    padding-bottom: 18px;
+    width: 100%;
+}

--- a/theme/padplus/scss/post/components/_buttons.scss
+++ b/theme/padplus/scss/post/components/_buttons.scss
@@ -11,6 +11,11 @@
     }
 }
 
+button,
+.btn {
+    white-space: nowrap;
+}
+
 .btn.btn-primary {
     background-color: theme-color("primary");
     border: solid 1px theme-color("primary");

--- a/theme/padplus/scss/post/layouts/_main.scss
+++ b/theme/padplus/scss/post/layouts/_main.scss
@@ -1,3 +1,19 @@
 #region-main {
     border: 0;
 }
+
+.header-page-container {
+    border-bottom: 3px solid theme-color('primary');
+    .page-context-header {
+        padding: 0;
+    }
+}
+
+.header-page-btns-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    div:first-child {
+        margin-bottom: 8px;
+    }
+}

--- a/theme/padplus/templates/core/full_header.mustache
+++ b/theme/padplus/templates/core/full_header.mustache
@@ -32,18 +32,29 @@
     <div class="col-12 pt-3 pb-3">
         <div class="card {{^contextheader}}border-0 bg-transparent{{/contextheader}}">
             <div class="card-body {{^contextheader}}p-2{{/contextheader}}">
-                <div class="d-sm-flex align-items-center">
+                <div class="d-flex flex-wrap">
+                    {{#hasnavbar}}
+                    <div class="breadcrumb-container" id="page-navbar">
+                        {{{navbar}}}
+                    </div>
+                    {{/hasnavbar}}
+                </div>
+                <div class="header-page-container d-sm-flex align-items-center mt-3 pb-3">
                     {{#contextheader}}
                     <div class="mr-auto">
                         {{{contextheader}}}
                     </div>
                     {{/contextheader}}
-
-                    {{#settingsmenu}}
-                    <div class="context-header-settings-menu">
-                        {{{settingsmenu}}}
+                    <div class="header-page-btns-container">
+                        <div>
+                            {{#settingsmenu}}
+                                {{{settingsmenu}}}
+                            {{/settingsmenu}}
+                        </div>
+                        <div>
+                            {{{pageheadingbutton}}}
+                        </div>
                     </div>
-                    {{/settingsmenu}}
                     <div class="header-actions-container flex-shrink-0" data-region="header-actions-container">
                         {{#headeractions}}
                             <div class="header-action ml-2">{{{.}}}</div>
@@ -51,14 +62,6 @@
                     </div>
                 </div>
                 <div class="d-flex flex-wrap">
-                    {{#hasnavbar}}
-                    <div id="page-navbar">
-                        {{{navbar}}}
-                    </div>
-                    {{/hasnavbar}}
-                    <div class="ml-auto d-flex">
-                        {{{pageheadingbutton}}}
-                    </div>
                     <div id="course-header">
                         {{{courseheader}}}
                     </div>


### PR DESCRIPTION
1. Modification de la structure du template **full_header.mustache** (surtout pour l'affichage du fil d'Ariane et le nouveau bouton d'administration).
2. Ajout du CSS complémentaire (fil d'Ariane + en-tête)
3. Ajout de nouvelles phrases dans le pack de langues.
4. On a remplacé le outputrenderer **public function context_header_settings_menu()**. Dans cette fonction, je n'ai remplacé que les 3 dernières boucles. Ces boucles déterminent si nous voyons ou non le bouton _Paramètres_ si nous sommes sur la page d'accueil, la page de profil ou la page cours en fonction de notre rôle.

J'ai décidé de ne pas supprimer la variable **$menu**, et **la boucle de la ligne 277**, bien qu'elle ne soit pas utilisée dans ces trois pages (accueil, profil, cours). J'ai des doutes sur le fait que l'effacer pourrait causer des bugs dans d'autres pages moodle.